### PR TITLE
[fix] SVG 해상도 관련 Memory 과사용 2.5GB -> 약 25MB ~ 33MB로 메모리 사용량 100배 감소

### DIFF
--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/노팅엄.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/노팅엄.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/뉴캐슬.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/뉴캐슬.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/레스터.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/레스터.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/루턴.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/루턴.imageset/Contents.json
@@ -2,20 +2,14 @@
   "images" : [
     {
       "filename" : "루턴.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/리버풀.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/리버풀.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/맨시티.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/맨시티.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/맨유.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/맨유.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/번리.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/번리.imageset/Contents.json
@@ -2,20 +2,14 @@
   "images" : [
     {
       "filename" : "번리.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/본머스.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/본머스.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/브라이턴.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/브라이턴.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/브렌트퍼드.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/브렌트퍼드.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/사우샘프턴.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/사우샘프턴.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/셰필드.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/셰필드.imageset/Contents.json
@@ -2,20 +2,14 @@
   "images" : [
     {
       "filename" : "셰필드.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/아스널.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/아스널.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/애스턴빌라.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/애스턴빌라.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/에버턴.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/에버턴.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/울버햄튼.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/울버햄튼.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/웨스트햄.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/웨스트햄.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/입스위치.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/입스위치.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/첼시.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/첼시.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/토트넘.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/토트넘.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/팰리스.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/팰리스.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/Resource/Assets.xcassets/Logo/풀럼.imageset/Contents.json
+++ b/DevilsDingDong/Resource/Assets.xcassets/Logo/풀럼.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/DevilsDingDong/View/TotalRecord/TotalRecordViewController.swift
+++ b/DevilsDingDong/View/TotalRecord/TotalRecordViewController.swift
@@ -19,7 +19,12 @@ class TotalRecordViewController: UIViewController {
         super.viewDidLoad()
         setUI()
         registerCell()
-        bindViewModel()
+        
+        viewModel.viewUpdateCloser = { [weak self] in
+            DispatchQueue.main.async {
+                self?.totalRecordView.collectionView.reloadData()
+            }
+        }
     }
 }
 
@@ -35,15 +40,6 @@ extension TotalRecordViewController {
     
     private func registerCell() {
         totalRecordView.collectionView.register(TotalRecordCell.self, forCellWithReuseIdentifier: TotalRecordCell.id)
-    }
-    
-    private func bindViewModel() {
-        viewModel.fetchScoreData()
-        viewModel.viewUpdateCloser = { [weak self] in
-            DispatchQueue.main.async {
-                self?.totalRecordView.collectionView.reloadData()
-            }
-        }
     }
 }
 

--- a/DevilsDingDong/ViewModel/TotalRecordViewModel.swift
+++ b/DevilsDingDong/ViewModel/TotalRecordViewModel.swift
@@ -9,25 +9,27 @@ import Foundation
 
 class TotalRecordViewModel {
     private let firebaseStoreManager = FirebaseStoreManager()
-    var scores: [Score] = [] {
-        didSet {
-            viewUpdateCloser?()
-           
-        }
-    }
+    var scores: [Score] = []
     var viewUpdateCloser: (() -> Void)?
+    private var isDataLoaded = false
+
+    init() {
+        fetchScoreData()
+        (viewUpdateCloser ?? {})()
+    }
     
     func fetchScoreData() {
+        guard !isDataLoaded else { return print("이미 Score가 Fetch 되었습니다") }
+
            firebaseStoreManager.fetchScoreFirestore(collection: "24-25_Score") { [weak self] (result: Result< ScoreList, Error>) in
-               DispatchQueue.main.async {
                    switch result {
                    case .success(let scoreList):
                        self?.scores = scoreList.scores
+                       self?.isDataLoaded = true
                        self?.sortScores()
                    case .failure(let error):
                        print("Error fetching scores: \(error)")
                    }
-               }
            }
        }
     


### PR DESCRIPTION
SVG 해상도 관련 Memory 과사용 2.5GB -> 약 25MB로 메모리 사용량 100배 감소
리그 순위 관련 스크롤 시 튕김 버그 수정

Resizing Preserve Vector Data 옵션 활성화로 메모리 사용량 감소 

<img width="263" alt="스크린샷 2024-08-27 오후 2 05 01" src="https://github.com/user-attachments/assets/484753e7-f1d9-41ae-b4d4-97f83c6d2042">
<img width="1511" alt="스크린샷 2024-08-27 오후 1 14 37" src="https://github.com/user-attachments/assets/a0a4b647-8b90-42fb-a233-c6b4382959f2">
<img width="1007" alt="스크린샷 2024-08-27 오후 1 46 04" src="https://github.com/user-attachments/assets/916e905f-7601-4a80-8c8f-4d125c772073">
